### PR TITLE
Add `files` to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   "license": "MIT",
   "author": "Józef Sokołowski <j.k.sokolowski@gmail.com>",
   "main": "lib/index.js",
+  "files": ["lib"],
   "scripts": {
     "commit": "git-cz",
     "commit:retry": "git-cz --retry",


### PR DESCRIPTION
This will prevent publishing unused runtime files to npm such as `test` 

https://docs.npmjs.com/files/package.json#files

Try running `npm pack` before and after to see the difference.