### PR TITLE
fix: improve performance of png and webp

### DIFF
--- a/lib/types/png.js
+++ b/lib/types/png.js
@@ -6,7 +6,6 @@ exports.isPNG = function (buffer) {
 exports.isAnimated = function (buffer) {
   var hasACTL = false
   var hasIDAT = false
-  var hasFDAT = false
 
   var previousChunkType = null
 
@@ -40,13 +39,13 @@ exports.isAnimated = function (buffer) {
           return false
         }
 
-        hasFDAT = true
-        break
+        // Return early since all 3 conditions met (ACTL, IDAT, fdAT)
+        return hasACTL
     }
 
     previousChunkType = chunkType
     offset += 4 + 4 + chunkLength + 4
   }
 
-  return (hasACTL && hasIDAT && hasFDAT)
+  return false
 }

--- a/lib/types/webp.js
+++ b/lib/types/webp.js
@@ -14,16 +14,25 @@ exports.isWebp = function (buffer) {
 }
 
 exports.isAnimated = function (buffer) {
-  var ANIM = [0x41, 0x4E, 0x49, 0x4D]
-  for (var i = 0; i < buffer.length; i++) {
-    for (var j = 0; j < ANIM.length; j++) {
-      if (buffer[i + j] !== ANIM[j]) {
-        break
-      }
-    }
-    if (j === ANIM.length) {
+  // WebP uses RIFF container format with chunks:
+  // 4 bytes chunk FourCC + 4 bytes chunk size + chunk data
+  // Start after RIFF header (4) + file size (4) + WEBP (4) = 12
+  var offset = 12
+
+  while (offset + 8 <= buffer.length) {
+    // Check if this chunk is ANIM (animation parameters)
+    if (buffer[offset] === 0x41 && // A
+        buffer[offset + 1] === 0x4E && // N
+        buffer[offset + 2] === 0x49 && // I
+        buffer[offset + 3] === 0x4D) { // M
       return true
     }
+
+    // Read chunk size (little-endian uint32) and skip to next chunk
+    var chunkSize = buffer.readUInt32LE(offset + 4)
+    // RIFF chunks are padded to even size
+    offset += 8 + chunkSize + (chunkSize % 2)
   }
+
   return false
 }


### PR DESCRIPTION
Disclosure - this was written by AI and modified by me.

Seeing up to 115x speed up for some of the test cases (regular.webp)

<details><summary>Toggle to view benchmark results</summary>
<p>

```txt
=== Real test files (static) ===

actl-chunk-after-fdat-chunks.png (521 bytes):
  old: 47.05ms total, 0.0005ms/op (100000 iterations)
  new: 44.38ms total, 0.0004ms/op (100000 iterations)
  speedup: 1.1x

idat-chunk-after-fdat-chunks.png (521 bytes):
  old: 45.87ms total, 0.0005ms/op (100000 iterations)
  new: 45.35ms total, 0.0005ms/op (100000 iterations)
  speedup: 1.0x

no-acTL-chunk.png (501 bytes):
  old: 37.89ms total, 0.0004ms/op (100000 iterations)
  new: 37.74ms total, 0.0004ms/op (100000 iterations)
  speedup: 1.0x

no-fcTL-chunk-before-IDAT-chunk.png (483 bytes):
  old: 40.50ms total, 0.0004ms/op (100000 iterations)
  new: 41.10ms total, 0.0004ms/op (100000 iterations)
  speedup: 1.0x

no-fcTL-chunks.png (407 bytes):
  old: 40.73ms total, 0.0004ms/op (100000 iterations)
  new: 40.55ms total, 0.0004ms/op (100000 iterations)
  speedup: 1.0x

no-fdAT-chunks.png (214 bytes):
  old: 56.69ms total, 0.0006ms/op (100000 iterations)
  new: 56.18ms total, 0.0006ms/op (100000 iterations)
  speedup: 1.0x

regular.gif (100 bytes):
  old: 22.10ms total, 0.0002ms/op (100000 iterations)
  new: 21.74ms total, 0.0002ms/op (100000 iterations)
  speedup: 1.0x

regular.png (156 bytes):
  old: 29.89ms total, 0.0003ms/op (100000 iterations)
  new: 30.46ms total, 0.0003ms/op (100000 iterations)
  speedup: 1.0x

regular.webp (10474 bytes):
  old: 1979.78ms total, 0.0198ms/op (100000 iterations)
  new: 17.12ms total, 0.0002ms/op (100000 iterations)
  speedup: 115.7x

with-comment-extension.gif (113 bytes):
  old: 23.54ms total, 0.0002ms/op (100000 iterations)
  new: 22.92ms total, 0.0002ms/op (100000 iterations)
  speedup: 1.0x

with-local-color-table.gif (106 bytes):
  old: 22.68ms total, 0.0002ms/op (100000 iterations)
  new: 25.99ms total, 0.0003ms/op (100000 iterations)
  speedup: 0.9x

with-plain-text-extension.gif (128 bytes):
  old: 24.42ms total, 0.0002ms/op (100000 iterations)
  new: 23.85ms total, 0.0002ms/op (100000 iterations)
  speedup: 1.0x

=== Real test files (invalid) ===

empty.gif (0 bytes):
  old: 7.52ms total, 0.0001ms/op (100000 iterations)
  new: 6.75ms total, 0.0001ms/op (100000 iterations)
  speedup: 1.1x

empty.webp (0 bytes):
  old: 5.50ms total, 0.0001ms/op (100000 iterations)
  new: 5.80ms total, 0.0001ms/op (100000 iterations)
  speedup: 0.9x

invalid-color-table-length.gif (216 bytes):
  old: 21.23ms total, 0.0002ms/op (100000 iterations)
  new: 20.91ms total, 0.0002ms/op (100000 iterations)
  speedup: 1.0x

invalid-header.gif (219 bytes):
  old: 15.26ms total, 0.0002ms/op (100000 iterations)
  new: 14.91ms total, 0.0001ms/op (100000 iterations)
  speedup: 1.0x

no-IDAT-chunk.png (372 bytes):
  old: 48.94ms total, 0.0005ms/op (100000 iterations)
  new: 48.99ms total, 0.0005ms/op (100000 iterations)
  speedup: 1.0x

=== Real test files (animated) ===

87a.gif (176 bytes):
  old: 22.36ms total, 0.0002ms/op (100000 iterations)
  new: 21.43ms total, 0.0002ms/op (100000 iterations)
  speedup: 1.0x

invalid-version.gif (219 bytes):
  old: 23.83ms total, 0.0002ms/op (100000 iterations)
  new: 23.77ms total, 0.0002ms/op (100000 iterations)
  speedup: 1.0x

no-fcTL-chunk-before-last-fdAT-chunk.png (483 bytes):
  old: 82.43ms total, 0.0008ms/op (100000 iterations)
  new: 64.72ms total, 0.0006ms/op (100000 iterations)
  speedup: 1.3x

no-graphic-control-extensions.gif (195 bytes):
  old: 23.50ms total, 0.0002ms/op (100000 iterations)
  new: 23.20ms total, 0.0002ms/op (100000 iterations)
  speedup: 1.0x

no-netscape-application-extension.gif (200 bytes):
  old: 23.68ms total, 0.0002ms/op (100000 iterations)
  new: 23.23ms total, 0.0002ms/op (100000 iterations)
  speedup: 1.0x

regular.gif (218 bytes):
  old: 24.50ms total, 0.0002ms/op (100000 iterations)
  new: 24.10ms total, 0.0002ms/op (100000 iterations)
  speedup: 1.0x

regular.png (521 bytes):
  old: 88.73ms total, 0.0009ms/op (100000 iterations)
  new: 60.80ms total, 0.0006ms/op (100000 iterations)
  speedup: 1.5x

regular.webp (41064 bytes):
  old: 23.66ms total, 0.0002ms/op (100000 iterations)
  new: 16.86ms total, 0.0002ms/op (100000 iterations)
  speedup: 1.4x

truncated-inside-second-frame.gif (151 bytes):
  old: 26.12ms total, 0.0003ms/op (100000 iterations)
  new: 26.68ms total, 0.0003ms/op (100000 iterations)
  speedup: 1.0x

truncated-inside-third-frame.gif (181 bytes):
  old: 25.14ms total, 0.0003ms/op (100000 iterations)
  new: 25.41ms total, 0.0003ms/op (100000 iterations)
  speedup: 1.0x

with-comment-extension.gif (232 bytes):
  old: 25.76ms total, 0.0003ms/op (100000 iterations)
  new: 25.96ms total, 0.0003ms/op (100000 iterations)
  speedup: 1.0x

with-empty-frames.gif (124 bytes):
  old: 24.83ms total, 0.0002ms/op (100000 iterations)
  new: 25.11ms total, 0.0003ms/op (100000 iterations)
  speedup: 1.0x

with-local-color-table.gif (225 bytes):
  old: 25.51ms total, 0.0003ms/op (100000 iterations)
  new: 25.56ms total, 0.0003ms/op (100000 iterations)
  speedup: 1.0x

with-plain-text-extension.gif (247 bytes):
  old: 25.88ms total, 0.0003ms/op (100000 iterations)
  new: 26.12ms total, 0.0003ms/op (100000 iterations)
  speedup: 1.0x

without-color-table.gif (195 bytes):
  old: 18.05ms total, 0.0002ms/op (100000 iterations)
  new: 18.13ms total, 0.0002ms/op (100000 iterations)
  speedup: 1.0x

zero-delays.gif (219 bytes):
  old: 25.10ms total, 0.0003ms/op (100000 iterations)
  new: 25.27ms total, 0.0003ms/op (100000 iterations)
  speedup: 1.0x
```

</p>

</details>
